### PR TITLE
Made initializing with string behave as expected.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function Select(opt) {
 		return new Select(opt)
 	EventEmitter.call(this)
 	opt = opt||{}
-	if (Array.isArray(opt))
+	if (Array.isArray(opt) || typeof opt == 'string')
 		opt = { data: opt }
 	this.element = opt.element || document.createElement("select")
 	this.data = []


### PR DESCRIPTION
Previously when calling the constructor with a string (`SelectBox('Test')`) it would wrap the name/value with `[90m` and `[39m`

e.g.

``` js
SelectBox('test').element.outerHTML
```

Produces:

``` html
<select><option value="[90mtest[39m">[90mtest[39m</option>
```

This patch amends this problem so:

``` js
SelectBox('test').element.outerHTML
```

Produces:

``` html
<select><option value="test">test</option>
```
